### PR TITLE
Bump System.Net.Http from 4.3.0 to 4.3.4 in /PokecordHelper

### DIFF
--- a/PokecordHelper/packages.config
+++ b/PokecordHelper/packages.config
@@ -37,7 +37,7 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.Sockets" version="4.3.0" targetFramework="net461" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
Bumps System.Net.Http from 4.3.0 to 4.3.4.

Signed-off-by: dependabot[bot] <support@github.com>