### PR TITLE
Bump System.Text.RegularExpressions in /PokecordHelper

### DIFF
--- a/PokecordHelper/packages.config
+++ b/PokecordHelper/packages.config
@@ -57,7 +57,7 @@
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net461" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net461" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net461" />
   <package id="System.Threading" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
Bumps System.Text.RegularExpressions from 4.3.0 to 4.3.1.

---
updated-dependencies:
- dependency-name: System.Text.RegularExpressions
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>